### PR TITLE
Fix misleading docstring about 'adaptive thresholds'

### DIFF
--- a/src/review-analyzer.ts
+++ b/src/review-analyzer.ts
@@ -169,7 +169,15 @@ export function analyzeReviewSeverity(reviewComment: string): {
 
 /**
  * Calculates code quality score based on review metrics
- * Uses weighted scoring algorithm with adaptive thresholds
+ * Uses weighted scoring algorithm with diminishing returns on critical issues
+ *
+ * Scoring behavior:
+ * - Base weights: critical (30), warning (15), suggestion (5)
+ * - Diminishing returns: First 3 critical issues at full penalty (30 each),
+ *   additional critical issues softened to 25 each (16.67% reduction)
+ * - LGTM bonus (+10) only for authorized reviewers with zero critical issues
+ * - LGTM penalty (-10) for authorized reviewers who approve despite critical issues
+ * - Category thresholds: excellent (90+), good (70+), needs-improvement (50+), critical (<50)
  *
  * SECURITY: LGTM scoring requires verified reviewer authorization.
  * Do NOT trust LGTM from parsed comment content - require server-side


### PR DESCRIPTION
## Summary
Fixes #22 - Replace misleading "adaptive thresholds" terminology with accurate description of the diminishing returns behavior.

## Changes
The `calculateQualityScore()` function docstring claimed to use "adaptive thresholds" but the implementation actually uses **fixed thresholds with diminishing returns** on critical issues.

Updated the docstring to accurately describe:
- **Base weights**: critical (30), warning (15), suggestion (5)
- **Diminishing returns**: First 3 critical issues at full penalty (30 each), additional critical issues softened to 25 each (16.67% reduction)
- **LGTM logic**: Bonus (+10) for authorized reviewers with zero critical issues, penalty (-10) for LGTM despite critical issues
- **Category thresholds**: excellent (90+), good (70+), needs-improvement (50+), critical (<50)

## Impact
- **Type**: Documentation accuracy
- **Severity**: Low-Medium
- **Files changed**: `src/review-analyzer.ts`
- **Tests**: All existing tests pass (no test changes required)

## Verification
```bash
yarn test  # All 85 tests pass
```