### PR TITLE
Fix: Add labeled event to gpt-5-pro workflow trigger

### DIFF
--- a/.github/workflows/cr-gpt5-pro.yml
+++ b/.github/workflows/cr-gpt5-pro.yml
@@ -6,7 +6,7 @@ permissions:
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize]
+    types: [opened, reopened, synchronize, labeled]
 
 jobs:
   code-review-gpt5-pro:


### PR DESCRIPTION
Fixes #7

The GPT-5 Pro workflow now subscribes to the labeled event type, allowing it to trigger when the gpt-5-pro label is applied after PR creation.

## Problem
The workflow only subscribed to opened, reopened, and synchronize events. When a PR was opened without the gpt-5-pro label and the label was added later (the common case), the workflow would never trigger.

## Solution
Added labeled to the event types in .github/workflows/cr-gpt5-pro.yml

## Impact
- Type: Bug fix
- Severity: High - restores intended automation functionality
- Affected file: .github/workflows/cr-gpt5-pro.yml